### PR TITLE
Container healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - "5432:5432"
     volumes:
       - database-data:/var/lib/postgresql/data/
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $${POSTGRES_USER}" ]
+      interval: 5s
+      timeout: 2s
+      retries: 5
 
   auth:
     build:
@@ -17,7 +22,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - database
+      database:
+        condition: service_healthy
 
   routing:
     build:


### PR DESCRIPTION
Обычно, когда мы пишем `depends_on` для нашего сервиса, он не будет ждать, пока другое приложение будет готово принимать соединения; это ожидание ограничено запуском самого контейнера, в котором крутится зависимый сервис.
Поэтому может возникнуть ситуация, когда, например, контейнер с бд поднялся, но сама база еще не запустилась и не готова принимать соединения.
Из-за этого, может случиться, что бэкенд попытается законнектиться к постгресу и упадет, не установив соединения.

Для решения таких ситуаций, у `depends_on` можно указать `condition`, на основе которого мы устанавливаем порядок запуска.
Нас здесь интересует статус `service_healthy`, для которого можно указать наш кастомный healthcheck для бд.

Прописав наш healthcheck для постгреса (см. pg_isready), при старте контейнера с базой, через указанные нами интервалы времени будет запускаться прописанный скрипт, чтобы определить состояние контейнера.

https://docs.docker.com/compose/startup-order/
https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
https://docs.docker.com/engine/reference/builder/#healthcheck
https://postgrespro.ru/docs/postgresql/9.6/app-pg-isready